### PR TITLE
Enable WhiteSource integration

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,11 @@
+{
+  "scanSettings": {
+    "configMode": "LOCAL"
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+} 

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,314 @@
+###############################################################
+# WhiteSource Unified-Agent configuration file
+# Copied from https://whitesource.atlassian.net/wiki/spaces/WD/pages/489160834/Unified+Agent+Configuration+File+Parameters on September 12 2019
+###############################################################
+
+# FINOS updated properties
+###############################################################
+npm.includeDevDependencies=false
+npm.runPreStep=true
+log.Level=debug
+# excludes=
+###############################################################
+
+# GENERAL SCAN MODE: Files and Package Managers
+###############################################################
+# Organization vitals
+######################
+
+#apiKey=
+#userKey is required if WhiteSource administrator has enabled "Enforce user level access" option
+#userKey=
+#requesterEmail=user@provider.com
+ 
+#projectName=
+#projectVersion=
+#projectToken=
+ 
+#productName=
+#productVersion=
+#productToken=
+ 
+#projectPerFolder=true
+#projectPerFolderIncludes=
+#projectPerFolderExcludes=
+ 
+#wss.connectionTimeoutMinutes=60
+ 
+# Change the below URL to your WhiteSource server.
+# Use the 'WhiteSource Server URL' which can be retrieved
+# from your 'Profile' page on the 'Server URLs' panel.
+# Then, add the '/agent' path to it.
+wss.url=https://saas.whitesourcesoftware.com/agent
+ 
+############
+# Policies #
+############
+checkPolicies=false
+forceCheckAllDependencies=false
+forceUpdate=false
+forceUpdate.failBuildOnPolicyViolation=false
+#updateInventory=false
+ 
+###########
+# General #
+###########
+#offline=false
+#updateType=APPEND
+#ignoreSourceFiles=true
+#scanComment=
+#failErrorLevel=ALL
+#requireKnownSha1=false
+ 
+#generateProjectDetailsJson=true
+#generateScanReport=true
+#scanReportTimeoutMinutes=10
+#scanReportFilenameFormat=
+ 
+#analyzeFrameworks=true
+#analyzeFrameworksReference=
+ 
+#updateEmptyProject=false
+ 
+########################################
+# Package Manager Dependency resolvers #
+########################################
+#resolveAllDependencies=false
+#excludeDependenciesFromNodes=.*commons-io.*,.*maven-model
+ 
+#npm.resolveDependencies=false
+#npm.ignoreSourceFiles=false
+#npm.includeDevDependencies=true
+#npm.runPreStep=true
+#npm.ignoreNpmLsErrors=true
+#npm.ignoreScripts=true
+#npm.yarnProject=true
+#npm.accessToken=
+#npm.identifyByNameAndVersion=true
+#npm.yarn.frozenLockfile=true
+#npm.resolveMainPackageJsonOnly=true
+#npm.removeDuplicateDependencies=false
+#npm.resolveAdditionalDependencies=true
+ 
+#bower.resolveDependencies=false
+#bower.ignoreSourceFiles=true
+#bower.runPreStep=true
+ 
+#nuget.resolvePackagesConfigFiles=false
+#nuget.resolveCsProjFiles=false
+#nuget.resolveDependencies=false
+#nuget.restoreDependencies=true
+#nuget.preferredEnvironment=
+#nuget.packagesDirectory=
+#nuget.ignoreSourceFiles=false
+#nuget.runPreStep=true
+#nuget.resolveNuspecFiles=false
+ 
+#python.resolveDependencies=false
+#python.ignoreSourceFiles=false
+#python.ignorePipInstallErrors=true
+#python.installVirtualenv=true
+#python.resolveHierarchyTree=false
+#python.requirementsFileIncludes=requirements.txt
+#python.resolveSetupPyFiles=true
+#python.runPipenvPreStep=true
+#python.pipenvDevDependencies=true
+#python.IgnorePipenvInstallErrors=true
+#python.resolveGlobalPackages=true
+ 
+#maven.ignoredScopes=test provided
+#maven.resolveDependencies=false
+#maven.ignoreSourceFiles=true
+#maven.aggregateModules=true
+#maven.ignorePomModules=false
+#maven.runPreStep=true
+#maven.ignoreMvnTreeErrors=true
+#maven.environmentPath=
+#maven.m2RepositoryPath=
+#maven.downloadMissingDependencies=false
+#maven.additionalArguments=
+ 
+#gradle.ignoredScopes=
+#gradle.resolveDependencies=false
+#gradle.runAssembleCommand=false
+#gradle.runPreStep=true
+#gradle.ignoreSourceFiles=true
+#gradle.aggregateModules=true
+#gradle.preferredEnvironment=wrapper
+#gradle.localRepositoryPath=
+#gradle.wrapperPath=
+#gradle.downloadMissingDependencies=false
+#gradle.additionalArguments=
+#gradle.includedScopes=
+#gradle.excludeModules=
+#gradle.includeModules=
+#gradle.includedConfigurations=
+#gradle.ignoredConfigurations=
+ 
+#paket.resolveDependencies=false
+#paket.ignoredGroups=
+#paket.ignoreSourceFiles=false
+#paket.runPreStep=true
+#paket.exePath=
+ 
+#go.resolveDependencies=false
+#go.collectDependenciesAtRuntime=true
+#go.dependencyManager=
+#go.ignoreSourceFiles=true
+#go.glide.ignoreTestPackages=false
+#go.gogradle.enableTaskAlias=true
+ 
+#ruby.resolveDependencies=false
+#ruby.ignoreSourceFiles=false
+#ruby.installMissingGems=true
+#ruby.runBundleInstall=true
+#ruby.overwriteGemFile=true
+ 
+#sbt.resolveDependencies=false
+#sbt.ignoreSourceFiles=true
+#sbt.aggregateModules=true
+#sbt.runPreStep=true
+ 
+#php.resolveDependencies=false
+#php.runPreStep=true
+#php.includeDevDependencies=true
+ 
+#html.resolveDependencies=false
+ 
+#cocoapods.resolveDependencies=false
+#cocoapods.runPreStep=true
+#cocoapods.ignoreSourceFiles=false
+ 
+#hex.resolveDependencies=false
+#hex.runPreStep=true
+#hex.ignoreSourceFiles=false
+#hex.aggregateModules=true
+ 
+#ant.resolveDependencies=false
+#ant.pathIdIncludes=.*
+#ant.external.parameters=
+ 
+#r.resolveDependencies=false
+#r.runPreStep=true
+#r.ignoreSourceFiles=false
+#r.cranMirrorUrl=
+ 
+#cargo.resolveDependencies=false
+#cargo.runPreStep=true
+#cargo.ignoreSourceFiles=false
+ 
+#haskell.resolveDependencies=false
+#haskell.runPreStep=true
+#haskell.ignoreSourceFiles=flase
+#haskell.ignorePreStepErrors=true
+ 
+###########################################################################################
+# Includes/Excludes Glob patterns - Please use only one exclude line and one include line #
+###########################################################################################
+#includes=**/*.c **/*.cc **/*.cp **/*.cpp **/*.cxx **/*.c++ **/*.h **/*.hpp **/*.hxx
+ 
+#includes=**/*.m **/*.mm  **/*.js **/*.php
+#includes=**/*.jar
+#includes=**/*.gem **/*.rb
+#includes=**/*.dll **/*.cs **/*.nupkg
+#includes=**/*.tgz **/*.deb **/*.gzip **/*.rpm **/*.tar.bz2
+#includes=**/*.zip **/*.tar.gz **/*.egg **/*.whl **/*.py
+ 
+case.sensitive.glob=false
+followSymbolicLinks=true
+ 
+######################
+# Archive properties #
+######################
+#archiveExtractionDepth=2
+#archiveIncludes=**/*.war **/*.ear
+#archiveExcludes=**/*sources.jar
+ 
+##############
+# SCAN MODES #
+##############
+ 
+# Docker images
+################
+#docker.scanImages=true
+#docker.includes=.*.*
+#docker.excludes=
+#docker.pull.enable=true
+#docker.pull.images=.*.*
+#docker.pull.maxImages=10
+#docker.pull.tags=.*.*
+#docker.pull.digest=
+#docker.delete.force=true
+#docker.login.sudo=false
+#docker.projectNameFormat=default
+ 
+#docker.aws.enable=true
+#docker.aws.registryIds=
+ 
+#docker.azure.enable=true
+#docker.azure.userName=
+#docker.azure.userPassword=
+#docker.azure.registryNames=
+ 
+#docker.artifactory.enable=true
+#docker.artifactory.url=
+#docker.artifactory.pullUrl=
+#docker.artifactory.userName=
+#docker.artifactory.userPassword=
+#docker.artifactory.repositoriesNames=
+#docker.artifactory.dockerAccessMethod=
+ 
+#docker.hub.enabled=true
+#docker.hub.userName=
+#docker.hub.userPassword=
+#docker.hub.organizationsNames=
+ 
+# Docker containers
+####################
+#docker.scanContainers=true
+#docker.containerIncludes=.*.*
+#docker.containerExcludes=
+ 
+# Linux package manager settings
+################################
+#scanPackageManager=true
+ 
+# Serverless settings
+######################
+#serverless.provider=
+#serverless.scanFunctions=true
+#serverless.includes=
+#serverless.excludes=
+#serverless.region=
+#serverless.maxFunctions=10
+ 
+# Artifactory settings
+########################
+#artifactory.enableScan=true
+#artifactory.url=
+#artifactory.accessToken=
+#artifactory.repoKeys=
+#artifactory.userName=
+#artifactory.userPassword=
+ 
+##################
+# Proxy settings #
+##################
+#proxy.host=
+#proxy.port=
+#proxy.user=
+#proxy.pass=
+ 
+################
+# SCM settings #
+################
+#scm.type=
+#scm.user=
+#scm.pass=
+#scm.ppk=
+#scm.url=
+#scm.branch=
+#scm.tag=
+#scm.npmInstall=
+#scm.npmInstallTimeoutMinutes=
+#scm.repositoriesFile=


### PR DESCRIPTION
As part of FINOS infrastructure, we are enabling WhiteSource security scanning across all our hosted projects; this PR contains the bot configuration.

After this PR gets merged, I will personally enable the WhiteSource GitHub app and the scanning will begin: every build descriptor (ie pom.xml, package.json, etc) will be executed and all direct/transitive dependencies will be scanned for security vulnerabilities.

If any vulnerability is found, by default a new GitHub issue will be created, with all details needed by the team to investigate further; there may be false positives (ie vulnerabilities spotted on non-runtime dependencies), which must be tackled by updating the WhiteSource bot configuration.

Please note that the public scope of these issues may pose a security threat for production environments; if that is the case, I can help you configuring WhiteSource to send email notifications, instead of using public GitHub Issues.

More info on WhiteSource security scanning can be found on https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/1129283585/WhiteSource+for+GitHub.com ; to know more about FINOS policies on how to manage a responsible disclosure of security issues, please read https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/1230176257/Security+Vulnerabilities+Responsible+Disclosure+Policy

Thank you!