### PR TITLE
Ensure style and links are included for inheritCSS

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -8532,7 +8532,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }

--- a/demo/src/pages/childWindow/ChildWindow.module.css
+++ b/demo/src/pages/childWindow/ChildWindow.module.css
@@ -31,3 +31,7 @@ label {
 .checkboxes {
     margin-bottom: 20px;
 }
+
+.external_style code {
+    color: navy;
+}

--- a/demo/src/pages/childWindow/ChildWindow.tsx
+++ b/demo/src/pages/childWindow/ChildWindow.tsx
@@ -20,7 +20,7 @@ const INITIAL_TEXT_AREA_VALUE: string = `<div class="App_containerApp__F0W0w">
 </div>`;
 const CHILD_BODY_AS_HOOK_OPTION = (
     <div className="App_containerApp__F0W0w">
-        <p>
+        <p className="ChildWindow_external_style__2s3g_">
             This jsx was passed in as a part of <code>CHILD_WINDOW_HOOK_OPTIONS</code>
             . See "Code Example" Section for more information.
     </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-react-hooks",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A collection of React Hooks built on top of the Openfin API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/useChildWindow.ts
+++ b/src/useChildWindow.ts
@@ -30,8 +30,11 @@ export default ({
 
     const inheritCss = useCallback(() => {
         if (parentDocument && htmlDocument) {
-            const parentStyles = parentDocument.getElementsByTagName("style");
-            injectNodes(parentStyles, htmlDocument);
+            const externalStyles =  parentDocument.styleSheets;
+            // tslint:disable-next-line: prefer-for-of
+            for (let i = 0; i < externalStyles.length; i ++ ) {
+                injectNode(externalStyles[i].ownerNode, htmlDocument);
+            }
         }
     }, [parentDocument, injectNodes, htmlDocument]);
 

--- a/src/utils/helpers/inject.ts
+++ b/src/utils/helpers/inject.ts
@@ -1,5 +1,5 @@
 export const injectNode = (
-    node: HTMLStyleElement | HTMLScriptElement,
+    node: HTMLStyleElement | HTMLScriptElement | Node,
     document: HTMLDocument,
 ) => {
     if (document) {


### PR DESCRIPTION
Currently CSS which is included within <link rel="stylesheet"> tags are not included into child windows when shouldInheritCss is selected. This can cause issues with applications which extract and minimise CSS from importing React components into a child window.

Fix modifies the shouldInheritCss method to ensure all style-sheet information is injected into a childWindow by using the parentDocument.styleSheets method instead of getElementsByTagName.
Updated the demo application as well to include a CSS property on the useChildWindow injected JSX component.
Issues are known to @ColinEberhardt who requested this to be investigated and fixed.