### PR TITLE
Fix useCallback hooks for version 9.61.38.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-react-hooks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-react-hooks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A collection of React Hooks built on top of the Openfin API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/useCallbackBaseHook.ts
+++ b/src/useCallbackBaseHook.ts
@@ -1,6 +1,6 @@
 import { Application } from "openfin/_v2/api/application/application";
 import { _Window } from "openfin/_v2/api/window/window";
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import ClosingOption from "./utils/types/enums/WindowClosingOptions";
 import usePreviousValue from "./utils/usePreviousValue";
 
@@ -58,14 +58,14 @@ export default (
         }
     };
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         getChildWindowsPromise()
             .then((windows) => {
                 setChildWindows(windows.map((w) => ({ name: w.identity.name, uuid: w.identity.uuid })));
             });
     }, []);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         app.addListener("window-created", handleWindowCreated);
 
         return () => {
@@ -74,7 +74,7 @@ export default (
 
     }, []);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         app.addListener("window-closed", handleWindowClosed);
 
         return () => {
@@ -83,11 +83,11 @@ export default (
 
     }, [childWindows]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         setChildrenCount(childWindows.length);
     }, [childWindows]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
 
         switch (closingOption) {
             case ClosingOption.AllChildren:
@@ -103,7 +103,7 @@ export default (
         }
     }, [childrenCount]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (shouldInvoke && windowThatJustClosed != null) {
             callbackFn(parent, fin.Window.wrapSync(windowThatJustClosed));
         }


### PR DESCRIPTION
Change to useLayoutEffect instead of useEffect because only using useEffect seems to make the window closing event listener unreliable (in some OpenFin versions).