### PR TITLE
Add explicit imports and exports for the OpenFinJavaScriptAPIVersion …

### DIFF
--- a/src/useChildWindow.ts
+++ b/src/useChildWindow.ts
@@ -9,6 +9,7 @@ import getChildWindows from "./utils/helpers/getChildWindows";
 import { injectNode, injectNodes } from "./utils/helpers/inject";
 import { isWindowV1, isWindowV2 } from "./utils/helpers/isWindow";
 import reducer, { INITIAL_WINDOW_STATE } from "./utils/reducers/WindowReducer";
+import OpenFinJavaScriptAPIVersion from "./utils/types/enums/OpenFinJavaScriptAPIVersion";
 import WINDOW_ACTION from "./utils/types/enums/WindowAction";
 import WINDOW_STATE from "./utils/types/enums/WindowState";
 

--- a/src/useNotification.ts
+++ b/src/useNotification.ts
@@ -16,6 +16,7 @@ import getChildWindows from "./utils/helpers/getChildWindows";
 import { injectNode, injectNodes } from "./utils/helpers/inject";
 import { isWindowV1, isWindowV2 } from "./utils/helpers/isWindow";
 import reducer, { INITIAL_WINDOW_STATE } from "./utils/reducers/WindowReducer";
+import OpenFinJavaScriptAPIVersion from "./utils/types/enums/OpenFinJavaScriptAPIVersion";
 import WINDOW_ACTION from "./utils/types/enums/WindowAction";
 import WINDOW_STATE from "./utils/types/enums/WindowState";
 

--- a/src/utils/helpers/createWindow.ts
+++ b/src/utils/helpers/createWindow.ts
@@ -1,5 +1,6 @@
 import { _Window } from "openfin/_v2/api/window/window";
 import { WindowOption } from "openfin/_v2/api/window/windowOption";
+import OpenFinJavaScriptAPIVersion from "../types/enums/OpenFinJavaScriptAPIVersion";
 
 const createWindowV1 = (options: WindowOption): Promise<fin.OpenFinWindow> =>
     new Promise((resolve, reject) => {

--- a/src/utils/helpers/getChildWindows.ts
+++ b/src/utils/helpers/getChildWindows.ts
@@ -1,4 +1,5 @@
 import { _Window } from "openfin/_v2/api/window/window";
+import OpenFinJavaScriptAPIVersion from "../types/enums/OpenFinJavaScriptAPIVersion";
 
 const getChildWindowsV1 = (): Promise<fin.OpenFinWindow[]> =>
     new Promise((resolve, reject) => {

--- a/src/utils/types/enums/OpenFinJavaScriptAPIVersion.ts
+++ b/src/utils/types/enums/OpenFinJavaScriptAPIVersion.ts
@@ -1,4 +1,4 @@
-const enum OpenFinJavaScriptAPIVersion {
+enum OpenFinJavaScriptAPIVersion {
     ONE,
     TWO,
 }

--- a/src/utils/types/enums/OpenFinJavaScriptAPIVersion.ts
+++ b/src/utils/types/enums/OpenFinJavaScriptAPIVersion.ts
@@ -2,3 +2,5 @@ const enum OpenFinJavaScriptAPIVersion {
     ONE,
     TWO,
 }
+
+export default OpenFinJavaScriptAPIVersion;


### PR DESCRIPTION
…to prevent compile errors when the Typescript config option 'isolatedModules' is set to true